### PR TITLE
Moved v out of version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
     - melund
     - ddale
     - cjermain
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "v0.4.2" %}
+{% set version = "0.4.2" %}
 {% set sha256 = "541616df177e13f914fca2f749c64f723d7b83c8ea9096509c9f318676ea91da" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ version }}.tar.gz
-  url: https://github.com/ralph-group/pymeasure/archive/{{ version }}.tar.gz
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/ralph-group/pymeasure/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
A dropped connection in Appveyor that can not be manually restarted prevented the Windows 32-bit package (Python 3.5) from building. This PR serves to re-trigger the builds. In the mean-time, the version number had a v in it which corresponded to the git tag. This is removed so that referencing the version does not require the v.
