### PR TITLE
Bumping version to 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.6" %}
-{% set sha256 = "ea60aca114d1663bf3fcc333939d120024853792dde80af999d1c3e0836470f2" %}
+{% set version = "0.6.1" %}
+{% set sha256 = "7440562e70a52a73e781415aa92587027c4a1f9ec4efefd4685908b510eb35b2" %}
 
 package:
   name: pymeasure


### PR DESCRIPTION
This PR bumps the version number to 0.6.1 to follow the latest release.