### PR TITLE
Bump version to v0.9 and adding new maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About pymeasure
 ===============
 
-Home: https://github.com/ralph-group/pymeasure
+Home: https://github.com/pymeasure/pymeasure
 
 Package license: MIT
 
@@ -9,7 +9,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pymeasure-feeds
 
 Summary: Scientific measurement library for instruments, experiments, and live-plotting.
 
-Development: https://github.com/ralph-group/pymeasure
+Development: https://github.com/pymeasure/pymeasure
 
 Documentation: http://pymeasure.readthedocs.io
 
@@ -238,4 +238,6 @@ Feedstock Maintainers
 * [@cjermain](https://github.com/cjermain/)
 * [@ddale](https://github.com/ddale/)
 * [@melund](https://github.com/melund/)
+* [@bilderbuchi](https://github.com/bilderbuchi/)
+* [@CasperSchippers](https://github.com/CasperSchippers/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.8" %}
-{% set sha256 = "38bd38dac8ba7fef95cce1ce6faff2d9d0b1947408c30f15695d6353d83d16a3" %}
+{% set version = "0.9" %}
+{% set sha256 = "048d7dc3df712a4f30aa1dbb826e5e97f5a14b98c747470b7590dcee5e3a5543" %}
 
 package:
   name: pymeasure
@@ -7,7 +7,7 @@ package:
 
 source:
   fn: v{{ version }}.tar.gz
-  url: https://github.com/ralph-group/pymeasure/archive/v{{ version }}.tar.gz
+  url: https://github.com/pymeasure/pymeasure/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -33,7 +33,7 @@ test:
     - pymeasure
 
 about:
-  home: https://github.com/ralph-group/pymeasure
+  home: https://github.com/pymeasure/pymeasure
   license: MIT
   license_file: LICENSE.txt
   summary: Scientific measurement library for instruments, experiments, and live-plotting.
@@ -44,10 +44,12 @@ about:
     experiments. Both parts of the package are independent, and when combined provide 
     all the necessary requirements for advanced measurements with only limited coding.
   doc_url: http://pymeasure.readthedocs.io
-  dev_url: https://github.com/ralph-group/pymeasure
+  dev_url: https://github.com/pymeasure/pymeasure
 
 extra:
   recipe-maintainers:
     - melund
     - ddale
     - cjermain
+    - bilderbuchi
+    - CasperSchippers


### PR DESCRIPTION
This PR bumps the version to 0.9. It also adds @bilderbuchi and @CasperSchippers as they are maintainers for the project.