### PR TITLE
bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d1df3c1bbd56a7ce3eaed36f8a76d35954d019e75b43962bd6c7b65028eae996
 
 build:
-  number: 0
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d1df3c1bbd56a7ce3eaed36f8a76d35954d019e75b43962bd6c7b65028eae996
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
@bilderbuchi my script wrongly detected it as a new version and reseted the build number. All other changes are, like pulling from PyPI and the extra test are desirable and built automatically with conda-skeleton or grayskull.