### PR TITLE
Set minimal python version to 3.8

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,18 +13,18 @@ source:
   sha256: 2867db427948ac3487b365c64ed5805507899808b08450285327f21e72a36ae1
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python ${{ python_min }}.*
+    - python 3.8.*
     - pip
     - setuptools
     - setuptools_scm >=8.1.0
   run:
-    - python >=${{ python_min }}
+    - python >=3.8
     - numpy >=1.6.1,<3
     - pandas >=0.14,<3
     - pint
@@ -40,7 +40,7 @@ tests:
   - requirements:
       run:
         - pip
-        - python ${{ python_min }}
+        - python 3.8.*
     script:
       - pip check
 


### PR DESCRIPTION
This PR hard codes the minimal python version instead of using the `python_min` variable. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
